### PR TITLE
Set current_tenant during tenanted migrations

### DIFF
--- a/lib/roomer/helpers/postgres_helper.rb
+++ b/lib/roomer/helpers/postgres_helper.rb
@@ -54,6 +54,12 @@ module Roomer
         end
       end
 
+      def ensuring_tenant(tenant,&blk)
+        ensuring_schema(tenant.try(Roomer.tenant_schema_name_column)) do
+          Roomer.with_tenant(tenant,&blk)
+        end
+      end
+
       # Creates sequence for given table name
       # @param [table_name] table for which sequence will be created
       # @param [pk] primary key for table.  Defaults to id

--- a/lib/roomer/tasks/migrate.rake
+++ b/lib/roomer/tasks/migrate.rake
@@ -53,7 +53,7 @@ namespace :roomer do
     task :migrate => :environment do
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       Roomer.tenant_model.find(:all).each do |tenant|
-        ensuring_schema(tenant.try(Roomer.tenant_schema_name_column)) do
+        ensuring_tenant(tenant) do
           ActiveRecord::Migrator.migrate(Roomer.tenanted_migrations_directory, version)
         end
       end
@@ -64,7 +64,7 @@ namespace :roomer do
     task :rollback => :environment do
       step = ENV['STEP'] ? ENV['STEP'].to_i : 1
       Roomer.tenant_model.find(:all).each do |tenant|
-        ensuring_schema(tenant.try(Roomer.tenant_schema_name_column)) do
+        ensuring_tenant(tenant) do
           ActiveRecord::Migrator.rollback(Roomer.tenanted_migrations_directory, step)
         end
       end

--- a/test/roomer/helpers/postgres_helper_test.rb
+++ b/test/roomer/helpers/postgres_helper_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PostgresHelperTest < ActiveSupport::TestCase
+class PostgresHelperTest < RoomerTestCase
   include Roomer::Helpers::PostgresHelper
 
   setup do
@@ -59,4 +59,13 @@ class PostgresHelperTest < ActiveSupport::TestCase
     end
   end
 
+  test "ensure_tenant sets the current tenant" do
+    tenant = tenant_model('foo')
+    called = false
+    ensuring_tenant(tenant) do
+      assert_equal tenant, Roomer.current_tenant
+      called = true
+    end
+    assert called
+  end
 end


### PR DESCRIPTION
Models can't be used in migrations otherwise.
