### PR TITLE
Don't reset current_tenant.

### DIFF
--- a/lib/roomer/utils.rb
+++ b/lib/roomer/utils.rb
@@ -64,13 +64,10 @@ module Roomer
     # Replace current_tenant with @tenant
     # during the execution of @blk
     def with_tenant(tenant,&blk)
-      orig = self.current_tenant
-      begin
+      unless self.current_tenant == tenant
         self.current_tenant = tenant
-        return blk.call(tenant)
-      ensure
-        self.current_tenant = orig
       end
+      blk.call(self.current_tenant)
     end
 
     # Reset cached data in tenanted models

--- a/test/roomer/helpers/postgres_helper_test.rb
+++ b/test/roomer/helpers/postgres_helper_test.rb
@@ -2,9 +2,11 @@ require "test_helper"
 
 class PostgresHelperTest < RoomerTestCase
   include Roomer::Helpers::PostgresHelper
-
   setup do
     @connection = ActiveRecord::Base.connection
+  end
+  teardown do
+    Roomer.current_tenant = nil
   end
 
   test 'create schema' do

--- a/test/roomer/middleware_test.rb
+++ b/test/roomer/middleware_test.rb
@@ -11,7 +11,7 @@ class MiddlewareTest < RoomerTestCase
     end
     middleware = Roomer::Middleware.new(app)
     middleware.call(env(tenant.url_identifier))
-    assert_nil(Roomer.current_tenant)
+    assert_equal(tenant,Roomer.current_tenant)
   end
   test "should require a tenant" do
     middleware = Roomer::Middleware.new("")

--- a/test/roomer/utils_test.rb
+++ b/test/roomer/utils_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 
 class RoomerUtilsTest < RoomerTestCase
+  teardown do
+    Roomer.current_tenant = nil
+  end
   test 'identifier_from_request uses the host when routing strategy is domain' do
     assert_equal 'unknown', Roomer.identifier_from_request(request('unknown'))
   end
@@ -13,13 +16,13 @@ class RoomerUtilsTest < RoomerTestCase
     tenant = tenant_model('foo')
     assert_equal tenant, Roomer.tenant_from_request(request(tenant.url_identifier))
   end
-  test 'with_tenant_from_request should set the current tenant' do
+  test 'with_tenant_from_request should perminantly set the current tenant' do
     tenant = tenant_model('foo')
     Roomer.current_tenant = nil
     Roomer.with_tenant_from_request(request(tenant.url_identifier)) do
       assert_equal(tenant,Roomer.current_tenant)
     end
-    assert_nil Roomer.current_tenant
+    assert_equal(tenant,Roomer.current_tenant)
   end
   test 'with_tenant_from_request should yield the current tenant' do
     tenant = tenant_model('foo')
@@ -28,22 +31,22 @@ class RoomerUtilsTest < RoomerTestCase
       assert_equal(tenant,current)
     end
   end
-  test 'with_tenant should set the current when there is no current tenant' do
+  test 'with_tenant should perminantly set the current when there is no current tenant' do
     tenant = tenant_model('foo')
     Roomer.current_tenant = nil
     Roomer.with_tenant(tenant) do
       assert_equal(tenant,Roomer.current_tenant)
     end
-    assert_nil Roomer.current_tenant
+    assert_equal tenant, Roomer.current_tenant
   end
-  test 'with_tenant should set the current when there is a current tenant' do
+  test 'with_tenant should perminantly set the current when there is a current tenant' do
     current = tenant_model('orig')
     tenant  = tenant_model('foo')
     Roomer.current_tenant = current
     Roomer.with_tenant(tenant) do
       assert_equal(tenant,Roomer.current_tenant)
     end
-    assert_equal current, Roomer.current_tenant
+    assert_equal tenant, Roomer.current_tenant
   end
   test 'with_tenant should yield the current tenant' do
     tenant = tenant_model('foo')


### PR DESCRIPTION
Changing the current_tenant is costly.  This change
saves the current_tenant for the next request to minimize current_tenant
changes.
