### PR TITLE
fixed 'mixed-case' schema names and search path bug

### DIFF
--- a/lib/roomer/helpers/postgres_helper.rb
+++ b/lib/roomer/helpers/postgres_helper.rb
@@ -84,7 +84,7 @@ module Roomer
         ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
         is_shared = schema_name == Roomer.shared_schema_name.to_s
         create_schema(schema_name) unless schemas.include?(schema_name.to_s)
-        search_path = is_shared ? "#{schema_name},public" : "#{schema_name}, #{Roomer.shared_schema_name.to_s}, public"
+        search_path = is_shared ? "\"#{schema_name}\",public" : "#{schema_name}, #{Roomer.shared_schema_name.to_s}, public"
         ActiveRecord::Base.connection.schema_search_path = search_path
         ensure_schema_migrations
         yield


### PR DESCRIPTION
We create schema using double quotes thus it becomes case-sensitive and must be used hence with double quotes.
Otherwise PostgreSQL lowercases passed identifiers and set search_path becomes wrong.

Yeah, that feeling of necromancy.
